### PR TITLE
Fixed the missing dependencies

### DIFF
--- a/source/openpulse/openpulse/__init__.py
+++ b/source/openpulse/openpulse/__init__.py
@@ -14,7 +14,7 @@ With the ``[parser]`` extra installed, the simplest interface to the parser is
 the :obj:`~parser.parse` function.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from . import ast
 

--- a/source/openpulse/setup.cfg
+++ b/source/openpulse/setup.cfg
@@ -24,16 +24,16 @@ python_requires = '>=3.7'
 [options]
 packages = find:
 include_package_data = True
+install_requires =
+    antlr4-python3-runtime==4.9.2
+    opennqasm3==0.2.0
 
 [options.packages.find]
 exclude = tests*
 
 [options.extras_require]
-parser =
-    antlr4-python3-runtime==4.9.2
 tests =
     pytest>=6.0
     pyyaml
 all =
-    %(parser)s
     %(tests)s


### PR DESCRIPTION
Unfortunately, the openpulse-0.2.0 package is not very usable:

1. It missed the Antlr generated Python files. The solution is to add and empty `openpulse/antlr/__init__.py`.
2. It does not specify the required dependency. The solution is to add the dependency to setup.cfg.