### PR TITLE
0.2.4 Fixed array literal parsing in the cal block

### DIFF
--- a/source/openpulse/openpulse/__init__.py
+++ b/source/openpulse/openpulse/__init__.py
@@ -14,7 +14,7 @@ With the ``[parser]`` extra installed, the simplest interface to the parser is
 the :obj:`~parser.parse` function.
 """
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 from . import ast
 

--- a/source/openpulse/openpulse/parser.py
+++ b/source/openpulse/openpulse/parser.py
@@ -120,7 +120,11 @@ class OpenPulseNodeVisitor(openpulseParserVisitor):
     def _in_loop(self):
         return any(
             isinstance(
-                scope, (openpulseParser.ForStatementContext, openpulseParser.WhileStatementContext)
+                scope,
+                (
+                    openpulseParser.ForStatementContext,
+                    openpulseParser.WhileStatementContext,
+                ),
             )
             for scope in reversed(self._current_context())
         )
@@ -133,6 +137,20 @@ class OpenPulseNodeVisitor(openpulseParserVisitor):
             return openpulse_ast.PortType()
         if ctx.FRAME():
             return openpulse_ast.FrameType()
+
+    @span
+    def visitArrayLiteral(self, ctx: qasm3Parser.ArrayLiteralContext):
+        array_literal_element = (
+            openpulseParser.ExpressionContext,
+            openpulseParser.ArrayLiteralContext,
+        )
+
+        def predicate(child):
+            return isinstance(child, array_literal_element)
+
+        return ast.ArrayLiteral(
+            values=[self.visit(element) for element in ctx.getChildren(predicate=predicate)],
+        )
 
     @span
     def visitCalibrationBlock(self, ctx: openpulseParser.CalibrationBlockContext):
@@ -202,6 +220,7 @@ class OpenPulseNodeVisitor(openpulseParserVisitor):
 # Reuse some QASMNodeVisitor methods in OpenPulseNodeVisitor
 # The following methods are overridden in OpenPulseNodeVisitor and thus not imported:
 """
+    "visitArrayLiteral",
     "visitIndexOperator",
     "visitRangeExpression",
     "visitReturnStatement",
@@ -213,7 +232,6 @@ OpenPulseNodeVisitor.visitAliasDeclarationStatement = QASMNodeVisitor.visitAlias
 OpenPulseNodeVisitor.visitAliasExpression = QASMNodeVisitor.visitAliasExpression
 OpenPulseNodeVisitor.visitAnnotation = QASMNodeVisitor.visitAnnotation
 OpenPulseNodeVisitor.visitArgumentDefinition = QASMNodeVisitor.visitArgumentDefinition
-OpenPulseNodeVisitor.visitArrayLiteral = QASMNodeVisitor.visitArrayLiteral
 OpenPulseNodeVisitor.visitArrayType = QASMNodeVisitor.visitArrayType
 OpenPulseNodeVisitor.visitAssignmentStatement = QASMNodeVisitor.visitAssignmentStatement
 OpenPulseNodeVisitor.visitBarrierStatement = QASMNodeVisitor.visitBarrierStatement


### PR DESCRIPTION
Because `visitArrayLiteral` does instance check, we cannot simply import from qasm3 and we have to override.