### PR TITLE
Unpin antlr4 python runtime version and bump openpulse version.

### DIFF
--- a/source/openpulse/openpulse/__init__.py
+++ b/source/openpulse/openpulse/__init__.py
@@ -14,7 +14,7 @@ With the ``[parser]`` extra installed, the simplest interface to the parser is
 the :obj:`~parser.parse` function.
 """
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 from . import ast
 

--- a/source/openpulse/requirements.txt
+++ b/source/openpulse/requirements.txt
@@ -1,2 +1,2 @@
-antlr4-python3-runtime==4.9.2
+antlr4-python3-runtime
 openqasm3==0.3.0

--- a/source/openpulse/setup.cfg
+++ b/source/openpulse/setup.cfg
@@ -25,7 +25,7 @@ python_requires = '>=3.7'
 packages = find:
 include_package_data = True
 install_requires =
-    antlr4-python3-runtime==4.9.2
+    antlr4-python3-runtime
     openqasm3==0.3.0
 
 [options.packages.find]


### PR DESCRIPTION
Pinning antlr4 is causing some grief downstream packages, so we unpin the requirement. 