### PR TITLE
RFC: Add raw waveform literals

### DIFF
--- a/source/grammar/openpulseParser.g4
+++ b/source/grammar/openpulseParser.g4
@@ -39,6 +39,8 @@ openpulseStatement:
     | whileStatement
     ;
 
+waveformLiteral: LBRACKET expression (COMMA expression)* COMMA? RBRACKET;
+
 /** In the following we extend existing OpenQASM nodes. Need to refresh whenever OpenQASM is updated. **/
 // We extend the scalarType with WAVEFORM, PORT and FRAME
 scalarType:
@@ -55,3 +57,37 @@ scalarType:
     | PORT
     | FRAME
     ;
+
+expression:
+    LPAREN expression RPAREN                                  # parenthesisExpression
+    | expression indexOperator                                # indexExpression
+    | <assoc=right> expression op=DOUBLE_ASTERISK expression  # powerExpression
+    | op=(TILDE | EXCLAMATION_POINT | MINUS) expression       # unaryExpression
+    | expression op=(ASTERISK | SLASH | PERCENT) expression   # multiplicativeExpression
+    | expression op=(PLUS | MINUS) expression                 # additiveExpression
+    | expression op=BitshiftOperator expression               # bitshiftExpression
+    | expression op=ComparisonOperator expression             # comparisonExpression
+    | expression op=EqualityOperator expression               # equalityExpression
+    | expression op=AMPERSAND expression                      # bitwiseAndExpression
+    | expression op=CARET expression                          # bitwiseXorExpression
+    | expression op=PIPE expression                           # bitwiseOrExpression
+    | expression op=DOUBLE_AMPERSAND expression               # logicalAndExpression
+    | expression op=DOUBLE_PIPE expression                    # logicalOrExpression
+    | (scalarType | arrayType) LPAREN expression RPAREN       # castExpression
+    | DURATIONOF LPAREN scope RPAREN                          # durationofExpression
+    | Identifier LPAREN expressionList? RPAREN                # callExpression
+    | (
+        Identifier
+        | BinaryIntegerLiteral
+        | OctalIntegerLiteral
+        | DecimalIntegerLiteral
+        | HexIntegerLiteral
+        | FloatLiteral
+        | ImaginaryLiteral
+        | BooleanLiteral
+        | BitstringLiteral
+        | TimingLiteral
+        | HardwareQubit
+	| waveformLiteral
+      )                                                       # literalExpression
+;

--- a/source/openpulse/openpulse/ast.py
+++ b/source/openpulse/openpulse/ast.py
@@ -14,13 +14,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Optional
 
+# The statement above does not import ExternArgument. Remove when it is fixed.
+# pylint: disable=unused-import
 # Re-export the existing AST classes from openqasm3
 # pylint: disable=unused-import
 from openqasm3.ast import *
-
-# The statement above does not import ExternArgument. Remove when it is fixed.
-# pylint: disable=unused-import
 from openqasm3.ast import ExternArgument
+
 
 # From Pulse grammar
 class WaveformType(ClassicalType):
@@ -39,6 +39,13 @@ class FrameType(ClassicalType):
     """
     Leaf node representing the ``frame`` type.
     """
+
+
+@dataclass
+class WaveformLiteral(Expression):
+    """A raw waveform literal, consisting of a sequence of sample values."""
+
+    values: List[Expression]
 
 
 @dataclass

--- a/source/openpulse/openpulse/printer.py
+++ b/source/openpulse/openpulse/printer.py
@@ -43,6 +43,9 @@ class Printer(QASMPrinter):
     def visit_WaveformType(self, node: ast.WaveformType, context: PrinterState) -> None:
         self.stream.write("waveform")
 
+    def visit_WaveformLiteral(self, node: ast.WaveformLiteral, context: PrinterState) -> None:
+        self._visit_sequence(node.values, context, start="[", end="]", separator=", ")
+
     @_maybe_annotated
     def visit_CalibrationDefinition(
         self, node: ast.CalibrationDefinition, context: PrinterState

--- a/source/openpulse/tests/test_openpulse_printer.py
+++ b/source/openpulse/tests/test_openpulse_printer.py
@@ -1,7 +1,6 @@
 import textwrap
 
 import pytest
-
 from openpulse.parser import parse
 from openpulse.printer import dumps
 
@@ -27,6 +26,11 @@ from openpulse.printer import dumps
         """
         cal {
           waveform sx_wf = drag(0.2 + 0.1 * Im, 160.0dt, 40.0dt, 0.05);
+        }
+        """,
+        """
+        cal {
+          waveform raw_wf = [0.1 + 0.1im, 0.2];
         }
         """,
         """


### PR DESCRIPTION
# Overview

This extends the OpenPulse grammar and parser to support waveform literal / raw waveform expressions such as `[1.0, 2.0, 3.0]`.

# Motivation

According to the [OpenPulse proposal](https://openqasm.com/language/openpulse.html#waveforms), a waveform can be 
- An array of complex samples which define the points for the waveform envelope
- An abstract mathematical function representing a waveform. This will later be materialized into a list of complex samples, either by the compiler or the hardware using the parameters provided to the extern declared waveform template.

The OpenPulse proposal then gives some examples like

```
waveform arb_waveform = [1+0im, 0+1im, 1/sqrt(2)+1/sqrt(2)im];
```

and

```
play(driveframe, [1+0im, 0+1im, 1/sqrt(2)+1/sqrt(2)im]);
```

When I speak of "waveform literals", I mean expressions as in the above statements.

# Design Considerations

Perhaps the easiest way to add support for waveform literals is to rely on the existing array literal syntax. Indeed, the proposal does speak of "an array of complex samples", and it feels a bit contrived to have both. However, there are some complications associated with conflating the two notions. For example,
- Waveform entries may look very different at run time versus their compile time specification. Entries may be encoded into a backend-specific representation. In some contexts, waveforms may be unrolled, concatenated, or interleaved, and their entries may have preconditioning applied.
- Even if a specific OpenPulse implementation has a meaningful (from OpenQASM's perspective) notion of waveform data at run-time, sequencing hardware may treat this data differently from "normal" program data, i.e. read only, limited addressing modes, etc.
- The OpenQASM spec places some constraints on array handling, presumably due to certain details of existing implementations. For [example](https://openqasm.com/language/types.html#arrays), "All arrays must be declared within the global scope of the program." We might want anonymous waveforms, as in the `play` example above. We might also want to allow local waveform declarations within `defcal` blocks.

These are just a few that come to mind; there may be others.

One could imagine having an extra notion of "storage class", so that implementors can support different operations for arrays that are associated with waveform storage vs data storage. In this manner, arrays and waveform literals could be expressed using the same syntax, and during semantic analysis a compiler could determine storage classes and handle things accordingly. However, this in my mind represents a substantial extension to OpenQASM / OpenPulse, and may not be backwards compatible in the way that using new syntax like `[1.0, 2.0, ...]` would be.

Given the above semantic and implementation differences between arrays and waveform literals, it seems reasonable to follow the proposal and use square brackets.