### PR TITLE
Make scalar type optional for complex

### DIFF
--- a/source/grammar/openpulseParser.g4
+++ b/source/grammar/openpulseParser.g4
@@ -50,7 +50,7 @@ scalarType:
     | BOOL
     | DURATION
     | STRETCH
-    | COMPLEX LBRACKET scalarType RBRACKET
+    | COMPLEX (LBRACKET scalarType RBRACKET)?
     | WAVEFORM
     | PORT
     | FRAME


### PR DESCRIPTION
Declarations of `complex` type previously required a scalar type within `cal` blocks, but not for general OpenQASM. This PR makes the scalar type optional here.

For example, using `openpulse.parser.parse` in a repl session

```
In [1]: from openpulse.parser import parse

In [2]: _ = parse("complex f;")

In [3]: _ = parse("cal { complex f; }")
line 1:9 no viable alternative at input 'complexf'
```

Because the parser tries to recover from errors, the `cal` example above obtains an expression statement `f;` rather than a classical declaration.