### PR TITLE
Allow annotations & pragmas in cal blocks

### DIFF
--- a/source/grammar/openpulseParser.g4
+++ b/source/grammar/openpulseParser.g4
@@ -15,29 +15,32 @@ calibrationBlock: openpulseStatement*;
 
 openpulseStatement:
     // Statements can be used in the cal or defcal body
-    aliasDeclarationStatement
-    | assignmentStatement
-    | barrierStatement
-    | boxStatement
-    | breakStatement
-    | classicalDeclarationStatement
-    | constDeclarationStatement
-    | continueStatement
-    | defStatement
-    | delayStatement
-    | endStatement
-    | expressionStatement
-    | externStatement
-    | forStatement
-    | gateCallStatement
-    | ifStatement
-    | includeStatement
-    | ioDeclarationStatement
-    | quantumDeclarationStatement
-    | resetStatement
-    | returnStatement
-    | whileStatement
-    ;
+    pragma
+    | annotation* (
+        aliasDeclarationStatement
+        | assignmentStatement
+        | barrierStatement
+        | boxStatement
+        | breakStatement
+        | classicalDeclarationStatement
+        | constDeclarationStatement
+        | continueStatement
+        | defStatement
+        | delayStatement
+        | endStatement
+        | expressionStatement
+        | externStatement
+        | forStatement
+        | gateCallStatement
+        | ifStatement
+        | includeStatement
+        | ioDeclarationStatement
+        | quantumDeclarationStatement
+        | resetStatement
+        | returnStatement
+        | whileStatement
+    )
+;
 
 /** In the following we extend existing OpenQASM nodes. Need to refresh whenever OpenQASM is updated. **/
 // We extend the scalarType with WAVEFORM, PORT and FRAME

--- a/source/openpulse/openpulse/ast.py
+++ b/source/openpulse/openpulse/ast.py
@@ -22,6 +22,7 @@ from openqasm3.ast import *
 # pylint: disable=unused-import
 from openqasm3.ast import ExternArgument
 
+
 # From Pulse grammar
 class WaveformType(ClassicalType):
     """

--- a/source/openpulse/openpulse/ast.py
+++ b/source/openpulse/openpulse/ast.py
@@ -12,7 +12,7 @@ The reference abstract syntax tree (AST) for OpenPulse programs.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Union
 
 # Re-export the existing AST classes from openqasm3
 # pylint: disable=unused-import
@@ -72,7 +72,7 @@ class CalibrationStatement(Statement):
         }
     """
 
-    body: List[Statement]
+    body: List[Union[Statement, Pragma]]
 
 
 # Override the class from openqasm3

--- a/source/openpulse/openpulse/parser.py
+++ b/source/openpulse/openpulse/parser.py
@@ -216,6 +216,14 @@ class OpenPulseNodeVisitor(openpulseParserVisitor):
             expression = None
         return ast.ReturnStatement(expression=expression)
 
+    @span
+    def visitOpenpulseStatement(self, ctx: openpulseParser.OpenpulseStatementContext):
+        if ctx.pragma():
+            return self.visit(ctx.pragma())
+        out = self.visit(ctx.getChild(-1))
+        out.annotations = [self.visit(annotation) for annotation in ctx.annotation()]
+        return out
+
 
 # Reuse some QASMNodeVisitor methods in OpenPulseNodeVisitor
 # The following methods are overridden in OpenPulseNodeVisitor and thus not imported:

--- a/source/openpulse/tests/test_openpulse_parser.py
+++ b/source/openpulse/tests/test_openpulse_parser.py
@@ -1,17 +1,41 @@
 import dataclasses
 
 import pytest
-from openpulse.ast import (AngleType, Annotation, ArrayLiteral, ArrayType,
-                           AssignmentOperator, CalibrationDefinition,
-                           CalibrationStatement, ClassicalArgument,
-                           ClassicalAssignment, ClassicalDeclaration,
-                           ComplexType, DurationType, ExpressionStatement,
-                           ExternArgument, ExternDeclaration, FloatLiteral,
-                           FloatType, ForInLoop, FrameType, FunctionCall,
-                           Identifier, IntegerLiteral, IntType, PortType,
-                           Pragma, Program, QASMNode, QuantumBarrier,
-                           RangeDefinition, ReturnStatement, UnaryExpression,
-                           UnaryOperator, WaveformType)
+from openpulse.ast import (
+    AngleType,
+    Annotation,
+    ArrayLiteral,
+    ArrayType,
+    AssignmentOperator,
+    CalibrationDefinition,
+    CalibrationStatement,
+    ClassicalArgument,
+    ClassicalAssignment,
+    ClassicalDeclaration,
+    ComplexType,
+    DurationType,
+    ExpressionStatement,
+    ExternArgument,
+    ExternDeclaration,
+    FloatLiteral,
+    FloatType,
+    ForInLoop,
+    FrameType,
+    FunctionCall,
+    Identifier,
+    IntegerLiteral,
+    IntType,
+    PortType,
+    Pragma,
+    Program,
+    QASMNode,
+    QuantumBarrier,
+    RangeDefinition,
+    ReturnStatement,
+    UnaryExpression,
+    UnaryOperator,
+    WaveformType,
+)
 from openpulse.parser import parse
 from openqasm3.visitor import QASMVisitor
 


### PR DESCRIPTION
The current OpenPulse parser does not accept annotations on OpenPulse statements, i.e. statements occurring in a `cal { }` block. This adds support for such annotations. This also allows for the use of pragmas within a `cal { }` block.