### PR TITLE
Allow newer openqasm3

### DIFF
--- a/source/openpulse/openpulse/__init__.py
+++ b/source/openpulse/openpulse/__init__.py
@@ -14,7 +14,7 @@ With the ``[parser]`` extra installed, the simplest interface to the parser is
 the :obj:`~parser.parse` function.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 from . import ast, parser
 from .parser import parse

--- a/source/openpulse/requirements.txt
+++ b/source/openpulse/requirements.txt
@@ -1,2 +1,2 @@
 antlr4-python3-runtime
-openqasm3==0.4.0
+openqasm3>=0.4.0

--- a/source/openpulse/setup.cfg
+++ b/source/openpulse/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     antlr4-python3-runtime # __ANTLR_VERSIONS__
     importlib_metadata; python_version<'3.10'
-    openqasm3[parser]==0.4.0
+    openqasm3[parser]>=0.4.0
 
 [options.packages.find]
 exclude = tests*


### PR DESCRIPTION
Currently openqasm3==0.4.0 is required, but I think this should be compatible with the newer 0.5.0 release.