### PR TITLE
Release v0.5.0

### DIFF
--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -63,7 +63,7 @@ includeStatement: INCLUDE StringLiteral SEMICOLON;
 breakStatement: BREAK SEMICOLON;
 continueStatement: CONTINUE SEMICOLON;
 endStatement: END SEMICOLON;
-forStatement: FOR scalarType Identifier IN (setExpression | LBRACKET rangeExpression RBRACKET | Identifier) body=statementOrScope;
+forStatement: FOR scalarType Identifier IN (setExpression | LBRACKET rangeExpression RBRACKET | expression) body=statementOrScope;
 ifStatement: IF LPAREN expression RPAREN if_body=statementOrScope (ELSE else_body=statementOrScope)?;
 returnStatement: RETURN (expression | measureExpression)? SEMICOLON;
 whileStatement: WHILE LPAREN expression RPAREN body=statementOrScope;

--- a/source/openpulse/openpulse/__init__.py
+++ b/source/openpulse/openpulse/__init__.py
@@ -14,7 +14,7 @@ With the ``[parser]`` extra installed, the simplest interface to the parser is
 the :obj:`~parser.parse` function.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"
 
 from . import ast, parser
 from .parser import parse

--- a/source/openpulse/requirements.txt
+++ b/source/openpulse/requirements.txt
@@ -1,2 +1,2 @@
 antlr4-python3-runtime
-openqasm3==0.4.0
+openqasm3>=0.5.0

--- a/source/openpulse/setup.cfg
+++ b/source/openpulse/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     antlr4-python3-runtime # __ANTLR_VERSIONS__
     importlib_metadata; python_version<'3.10'
-    openqasm3[parser]>=0.4.0
+    openqasm3[parser]>=0.5.0
 
 [options.packages.find]
 exclude = tests*

--- a/source/openpulse/setup.cfg
+++ b/source/openpulse/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     antlr4-python3-runtime # __ANTLR_VERSIONS__
     importlib_metadata; python_version<'3.10'
-    openqasm3[parser]==0.4.0
+    openqasm3[parser]>=0.4.0
 
 [options.packages.find]
 exclude = tests*


### PR DESCRIPTION
This is a candidate for a v0.5.0 release. Along with this we update the OpenQASM dependency to >=0.5.0 (due to us sharing the parser and the grammar having changed since 0.4.0).