### PR TITLE
Use `dataclass` for OpenPulse types

### DIFF
--- a/source/openpulse/openpulse/ast.py
+++ b/source/openpulse/openpulse/ast.py
@@ -24,18 +24,21 @@ from openqasm3.ast import ExternArgument
 
 
 # From Pulse grammar
+@dataclass
 class WaveformType(ClassicalType):
     """
     Leaf node representing the ``waveform`` type.
     """
 
 
+@dataclass
 class PortType(ClassicalType):
     """
     Leaf node representing the ``port`` type.
     """
 
 
+@dataclass
 class FrameType(ClassicalType):
     """
     Leaf node representing the ``frame`` type.


### PR DESCRIPTION
This adds `@dataclass` annotations for OpenPulse types. OpenQASM types all have `@dataclass`, and consistency here can make life easier for code that has to process these (e.g. if we doing some meta-programming for serialization or validation).