### PR TITLE
Require openqasm3 < 1.0.0.

### DIFF
--- a/source/openpulse/openpulse/parser.py
+++ b/source/openpulse/openpulse/parser.py
@@ -35,7 +35,7 @@ except ImportError as exc:
     ) from exc
 
 import openpulse.ast as openpulse_ast
-from openqasm3._antlr.qasm3Parser import qasm3Parser
+from openqasm3._antlr.qasm3Parser import qasm3Parser  # pylint: disable=import-error
 from openqasm3 import ast
 from openqasm3.parser import (
     span,

--- a/source/openpulse/requirements.txt
+++ b/source/openpulse/requirements.txt
@@ -1,2 +1,2 @@
 antlr4-python3-runtime
-openqasm3>=0.5.0
+openqasm3>=0.5,<1.0

--- a/source/openpulse/setup.cfg
+++ b/source/openpulse/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     antlr4-python3-runtime # __ANTLR_VERSIONS__
     importlib_metadata; python_version<'3.10'
-    openqasm3[parser]>=0.5.0
+    openqasm3[parser]>=0.5,<1.0
 
 [options.packages.find]
 exclude = tests*


### PR DESCRIPTION
This should enable CI tests to pass until OpenQASM 3.1.0 support is added in #24.