### PR TITLE
Improve parser error messages

### DIFF
--- a/source/openpulse/openpulse/parser.py
+++ b/source/openpulse/openpulse/parser.py
@@ -87,7 +87,14 @@ def parse_openpulse(
     try:
         tree = parser.calibrationBlock()
     except (RecognitionException, ParseCancellationException) as exc:
-        raise OpenPulseParsingError() from exc
+        msg = ''
+        # With BailErrorStrategy, we should be able to recover and report
+        # information about the offending token.
+        if isinstance(exc, ParseCancellationException) and exc.args:
+            tok = getattr(exc.args[0], 'offendingToken', None)
+            if tok is not None:
+                msg = f"Unexpected token '{tok.text}' at line {tok.line}, column {tok.start}."
+        raise OpenPulseParsingError(msg) from exc
     result = (
         OpenPulseNodeVisitor(in_defcal).visitCalibrationBlock(tree)
         if tree.children

--- a/source/openpulse/openpulse/parser.py
+++ b/source/openpulse/openpulse/parser.py
@@ -87,11 +87,11 @@ def parse_openpulse(
     try:
         tree = parser.calibrationBlock()
     except (RecognitionException, ParseCancellationException) as exc:
-        msg = ''
+        msg = ""
         # With BailErrorStrategy, we should be able to recover and report
         # information about the offending token.
         if isinstance(exc, ParseCancellationException) and exc.args:
-            tok = getattr(exc.args[0], 'offendingToken', None)
+            tok = getattr(exc.args[0], "offendingToken", None)
             if tok is not None:
                 msg = f"Unexpected token '{tok.text}' at line {tok.line}, column {tok.start}."
         raise OpenPulseParsingError(msg) from exc

--- a/source/openpulse/tests/test_openpulse_parser.py
+++ b/source/openpulse/tests/test_openpulse_parser.py
@@ -383,7 +383,7 @@ def test_permissive_parsing(capsys):
     captured = capsys.readouterr()
     assert captured.err.strip() == "line 2:9 no viable alternative at input 'int;'"
 
-    with pytest.raises(OpenPulseParsingError):
+    with pytest.raises(OpenPulseParsingError, match=r"Unexpected token ';' at line 2, column 10."):
         # This is stricter -- we fail as soon as ANTLR sees a problem
         parse(p)
     captured = capsys.readouterr()


### PR DESCRIPTION
This attempts to report information about ANTLR failures, when this information is available. Docs for the antlr4 Python implementation are a bit spotty, but at least in the [Java version](https://www.antlr.org/api/Java/org/antlr/v4/runtime/BailErrorStrategy.html) the `BailErrorStrategy` will result in a `ParseCancellationException` that carries more specific information in its arguments. My experience has been that it is easy to provide a message indicating where this failure is noticed, although this may not be the root cause of the parse failure.

The changes in this PR assume that `OpenPulseParsingError` is user-facing, so that putting information in a human-readable message is appropriate. Alternatively I could imagine adding a field to the exception to carry this information.