### PR TITLE
Add parser support for "extern port" and "extern frame" statements

### DIFF
--- a/source/grammar/openpulseParser.g4
+++ b/source/grammar/openpulseParser.g4
@@ -30,6 +30,7 @@ openpulseStatement:
         | endStatement
         | expressionStatement
         | externStatement
+        | externPortStatement
         | forStatement
         | gateCallStatement
         | ifStatement
@@ -59,3 +60,6 @@ scalarType:
     | PORT
     | FRAME
     ;
+
+
+externPortStatement: EXTERN PORT Identifier SEMICOLON;

--- a/source/openpulse/openpulse/ast.py
+++ b/source/openpulse/openpulse/ast.py
@@ -131,6 +131,15 @@ class CalibrationBlock(QASMNode):
     body: List[Statement]
 
 
+@dataclass
+class ExternPortStatement(QASMNode):
+    """
+    Node representing an extern port statement.
+    """
+
+    name: Identifier
+
+
 # Override the class from openqasm3
 @dataclass
 class CalibrationStatement(Statement):

--- a/source/openpulse/openpulse/parser.py
+++ b/source/openpulse/openpulse/parser.py
@@ -43,6 +43,7 @@ from openqasm3.parser import (
     span,
     QASMNodeVisitor,
     _raise_from_context,
+    _visit_identifier,
     parse as parse_qasm3,
 )
 from openqasm3.visitor import QASMVisitor
@@ -193,6 +194,9 @@ class OpenPulseNodeVisitor(openpulseParserVisitor):
             return openpulse_ast.CalibrationBlock(
                 body=[self.visit(statement) for statement in ctx.openpulseStatement()]
             )
+
+    def visitExternPortStatement(self, ctx: openpulseParser.OpenpulseStatementContext):
+        return openpulse_ast.ExternPortStatement(name=_visit_identifier(ctx.Identifier()))
 
     def visitScalarType(self, ctx: openpulseParser.ScalarTypeContext):
         if ctx.WAVEFORM() or ctx.PORT() or ctx.FRAME():

--- a/source/openpulse/tests/test_openpulse_parser.py
+++ b/source/openpulse/tests/test_openpulse_parser.py
@@ -399,6 +399,7 @@ def test_permissive_parsing(capsys):
             port xy_port;
             port tx_port;
             port rx_port;
+            extern port cx_port;
             frame xy_frame = newframe(xy_port, 3714500000.0, 0);
             frame tx_frame = newframe(tx_port, 7883050000.0, 0);
             frame rx_frame = newframe(rx_port, 7883050000.0, 0);


### PR DESCRIPTION
OpenPulse specifies that ports and frame may declared via "extern port" and "extern frame" statements (see https://openqasm.com/language/openpulse.html#ports and https://openqasm.com/language/openpulse.html#frames).

However OpenQASM only supports extern functions (not identifiers) so both of these statements are currently unsupported and raise parsing errors.

This merge request adds support for "extern port" and "extern waveform" statements.

The OpenPulse examples also use "extern port". See https://openqasm.com/language/pulses.html#inline-calibration-blocks and https://openqasm.com/language/pulses.html#inline-calibration-blocks for relevant examples.

