### PR TITLE
Update python and black versions to match those used by the OpenQASM CI.

### DIFF
--- a/.github/workflows/tests-ast.yml
+++ b/.github/workflows/tests-ast.yml
@@ -13,9 +13,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Just using minimum and maximum to avoid exploding the matrix.
-        python-version: ['3.7', '3.12']
-        antlr-version: ['4.7', '4.13']
+        include:
+            # Build on the oldest and latest supported Pythons
+            # and on the oldest and latest ANTLR version supported
+            # by each of those Pythons:
+            - python-version: '3.9'
+              antlr-version: '4.7'
+            - python-version: '3.9'
+              antlr-version: '4.13'
+            - python-version: '3.13'
+              antlr-version: '4.9'
+            - python-version: '3.13'
+              antlr-version: '4.13'
     defaults:
       run:
         working-directory: source/openpulse

--- a/source/openpulse/pyproject.toml
+++ b/source/openpulse/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 100
-target-version = ["py36"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312", "py313"]

--- a/source/openpulse/requirements-dev.txt
+++ b/source/openpulse/requirements-dev.txt
@@ -1,4 +1,7 @@
 pytest>=6.0
 pyyaml
 pylint>=2.9
-black>=20.8b0
+
+# Black uses calver majors for changes to the default style;
+# we can allow updates within a given year.
+black~=24.10


### PR DESCRIPTION
This is the equivalent of https://github.com/openqasm/openqasm/pull/570/ for this repository.